### PR TITLE
fix ynh_replace & sed cmd

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -11,7 +11,7 @@ ynh_script_progression "Setting up source files..."
 ynh_setup_source --dest_dir="$install_dir"
 
 # Replace official app domain with current YNH instance's    
-ynh_replace --match="https://it-tools.tech" --replace="$domain" --file="$install_dir/index.html"
+ynh_replace --match="https://it-tools.tech" --replace="https://$domain$path" --file="$install_dir/index.html"
 
 # Fix relative paths
 ynh_replace --match="/assets" --replace="./assets" --file="$install_dir/index.html"
@@ -19,7 +19,7 @@ ynh_replace --match="/manifest." --replace="./manifest." --file="$install_dir/in
 
 # Set home route at app root rather than at domain root
 main_js=$(grep -o 'crossorigin src=\"\./assets.*\.js' $install_dir/index.html | cut -d/ -f3-) # e.g.: index-65600c6f.js
-sed -Ei "s@routes:\[\{path:\"\/\",name:\"home\",component:qre\}@routes:\[\{path:\"$path\",name:\"home\",component:qre\}@g" "$install_dir/assets/$main_js" 
+sed -Ei "s@routes:\[\{path:\"\/\",name:\"home\"@routes:\[\{path:\"$path\",name:\"home\"@g" "$install_dir/assets/$main_js" 
 
 # Make home button link point to app root
 sed -i "s@{to:\"/\",circle:\"\",variant:\"text\",\"aria-label\":p\.\$t(\"home\.home\")\}@{to:\"$path\",circle:\"\",variant:\"text\",\"aria-label\":p\.\$t(\"home\.home\")\}@g" "$install_dir/assets/$main_js" 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -11,7 +11,7 @@ ynh_script_progression "Upgrading source files..."
 ynh_setup_source --dest_dir="$install_dir" --full_replace
 
 # Replace official app domain with current YNH instance's    
-ynh_replace --match="https://it-tools.tech" --replace="$domain" --file="$install_dir/index.html"
+ynh_replace --match="https://it-tools.tech" --replace="https://$domain$path" --file="$install_dir/index.html"
 
 # Fix relative paths
 ynh_replace --match="/assets" --replace="./assets" --file="$install_dir/index.html"
@@ -19,7 +19,7 @@ ynh_replace --match="/manifest." --replace="./manifest." --file="$install_dir/in
 
 # Set home route at app root rather than at domain root
 main_js=$(grep -o 'crossorigin src=\"\./assets.*\.js' $install_dir/index.html | cut -d/ -f3-) # e.g.: index-65600c6f.js
-sed -Ei "s@routes:\[\{path:\"\/\",name:\"home\",component:qre\}@routes:\[\{path:\"$path\",name:\"home\",component:qre\}@g" "$install_dir/assets/$main_js" 
+sed -Ei "s@routes:\[\{path:\"\/\",name:\"home\"@routes:\[\{path:\"$path\",name:\"home\"@g" "$install_dir/assets/$main_js" 
 
 # Make home button link point to app root
 sed -i "s@{to:\"/\",circle:\"\",variant:\"text\",\"aria-label\":p\.\$t(\"home\.home\")\}@{to:\"$path\",circle:\"\",variant:\"text\",\"aria-label\":p\.\$t(\"home\.home\")\}@g" "$install_dir/assets/$main_js" 


### PR DESCRIPTION
- ynh_replace --match="https://it-tools.tech" has to be replaced by full URL including https and $path.
- `sed -Ei "s@routes:\[\{path:\"\/`...` was failing after update as it was including in the match portion a function (`qre`) whose name is a minimized string which differs at each build.

