### PR TITLE
Upgrade to v2025.05.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Collection of handy online tools for developers
 
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://sharevb-it-tools.vercel.app)
-[![Version: 2025.05.17~ynh1](https://img.shields.io/badge/Version-2025.05.17~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
+[![Version: 2025.05.11~ynh1](https://img.shields.io/badge/Version-2025.05.11~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/it-tools"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Collection of handy online tools for developers
 
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://sharevb-it-tools.vercel.app)
-[![Version: 2025.05.11~ynh1](https://img.shields.io/badge/Version-2025.05.11~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
+[![Version: 2025.05.17~ynh1](https://img.shields.io/badge/Version-2025.05.17~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/it-tools"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "IT Tools"
 description.en = "Collection of handy online tools for developers"
 description.fr = "Collection d'outils pratiques en ligne pour les développeurs"
 
-version = "2025.05.11~ynh1"
+version = "2025.05.17~ynh1"
 
 maintainers = ["oleole39"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -45,13 +45,13 @@ ram.runtime = "20M"
 
         [resources.sources.upstream]
         # This is not used as we are using git clone. It's only here for autoupdate.
-        url = "https://github.com/sharevb/it-tools/archive/f3d5ab82620991bf8ab19630cc1fe42588d200fc.tar.gz"
-        sha256 = "38ef9c95803c89955f2baacf5c5947c6dd8036a99d941b0bb6a38617856e1ae6"
+        url = "https://github.com/sharevb/it-tools/archive/48854592b0eabc5e36cbee2da345c6199db6742a.tar.gz"
+        sha256 = "4c500bb4ff01f4e40c82f802a9994b43e2c0be9e524ea3f82cbb2617b869cff3"
         prefetch = false
         autoupdate.strategy = "latest_github_commit"
         
         [resources.sources.ynh_build]
-        url = "https://github.com/Yunohost-Apps/it-tools_ynh/releases/download/v2025.05.17-48854592/it-tools_v2025.05.17-48854592_ynh.zip"
+        url = "https://github.com/YunoHost-Apps/it-tools_ynh/releases/download/v2025.05.17-48854592/it-tools_v2025.05.17-48854592_ynh.zip"
         sha256 = "59df11219b3c2dbcf0337092d46014274cdf73ae6fc6be8a53e3eeba81916b31"
         format = "zip"
         extract = true


### PR DESCRIPTION
Upgrade sources
- `upstream` v2025.05.17: https://github.com/sharevb/it-tools/compare/f3d5ab82620991bf8ab19630cc1fe42588d200fc...48854592b0eabc5e36cbee2da345c6199db6742a

On demand build and manual pull request as previous release somehow failed (could be upstream, or issue related to git history and wrong upgrade push)