### PR TITLE
Upgrade to v2025.10.19-c1b06940

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Collection of handy online tools for developers
 
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://sharevb-it-tools.vercel.app)
-[![Version: 2025.10.12~ynh2](https://img.shields.io/badge/Version-2025.10.12~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
+[![Version: 2025.10.19~ynh1](https://img.shields.io/badge/Version-2025.10.19~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/it-tools"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -53,8 +53,8 @@ ram.runtime = "20M"
         autoupdate.strategy = "latest_github_commit"
         
         [resources.sources.ynh_build]
-        url = "https://github.com/YunoHost-Apps/it-tools_ynh/releases/download/v2025.10.12-37164f3c/it-tools_v2025.10.12-37164f3c_ynh.zip"
-        sha256 = "32b8746d4593cd0ccd468d69b09e209ab7837c648da06ffa8191dfdd5a5e943e"
+        url = "https://github.com/YunoHost-Apps/it-tools_ynh/releases/download/v2025.10.19-c1b06940/it-tools_v2025.10.19-c1b06940_ynh.zip"
+        sha256 = "7bf9f3cc5b8e435761ae697313077701fc8815139ac54802945626485f14476b"
         format = "zip"
         extract = true
         in_subdir = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "IT Tools"
 description.en = "Collection of handy online tools for developers"
 description.fr = "Collection d'outils pratiques en ligne pour les développeurs"
 
-version = "2025.10.12~ynh2"
+version = "2025.10.19~ynh1"
 
 maintainers = ["oleole39"]
 
@@ -47,8 +47,8 @@ ram.runtime = "20M"
 
         [resources.sources.main]
         # This is not used as we are using git clone. It's only here for autoupdate.
-        url = "https://github.com/sharevb/it-tools/archive/37164f3cede2107f439eb141a13ebb294c9d5249.tar.gz"
-        sha256 = "0f41c14f5fa530a59e00723953fcc5d64b945808f772457d240f2b08da1477fe"
+        url = "https://github.com/sharevb/it-tools/archive/c1b06940970eccc5c9eae97a1b23f5bff84fcebe.tar.gz"
+        sha256 = "7887785b7c8434a4e6a7051e5a9eaf614debf3372f7c3817e61e4d6c7980201f"
         prefetch = false
         autoupdate.strategy = "latest_github_commit"
         


### PR DESCRIPTION
Upstream upgrade is now built for YNH and ready to be released in the current repository: https://github.com/YunoHost-Apps/it-tools_ynh/releases/tag/untagged-a1fb34e04f21ddc183b1
 - [x] Make sure the release is published before testing this PR.

