### PR TITLE
v2026.02.22-90e18130

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Collection of handy online tools for developers
 
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://sharevb-it-tools.vercel.app)
-[![Version: 2026.02.15~ynh1](https://img.shields.io/badge/Version-2026.02.15~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
+[![Version: 2026.02.22~ynh1](https://img.shields.io/badge/Version-2026.02.22~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/it-tools/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/it-tools"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "IT Tools"
 description.en = "Collection of handy online tools for developers"
 description.fr = "Collection d'outils pratiques en ligne pour les développeurs"
 
-version = "2026.02.15~ynh1"
+version = "2026.02.22~ynh1"
 
 maintainers = ["oleole39"]
 
@@ -47,8 +47,8 @@ ram.runtime = "20M"
 
         [resources.sources.main]
         # This is not used as we are using git clone. It's only here for autoupdate.
-        url = "https://github.com/sharevb/it-tools/archive/c2f9e6249cda9911e2cb9fc7d60daf942799f230.tar.gz"
-        sha256 = "e45ac50f3e56aced2f6e171dcd3ff2b3108a453bdf24b75d9ab79a21b979835e"
+        url = "https://github.com/sharevb/it-tools/archive/90e18130031d381ea49f896b7dceb15d9790bc9e.tar.gz"
+        sha256 = "2ec6ba2ddfb306b146fb7aacf2ae13fa71ff41d880163b0df0fd381155ddce30"
         prefetch = false
         autoupdate.strategy = "latest_github_commit"
         

--- a/manifest.toml
+++ b/manifest.toml
@@ -53,8 +53,8 @@ ram.runtime = "20M"
         autoupdate.strategy = "latest_github_commit"
         
         [resources.sources.ynh_build]
-        url = "https://github.com/YunoHost-Apps/it-tools_ynh/releases/download/v2026.02.15-c2f9e624/it-tools_v2026.02.15-c2f9e624_ynh.zip"
-        sha256 = "e29fb5cb4be10d5bcf80517a9bfeb9624df9c207e645554bd3dab6c6d922788d"
+        url = "https://github.com/YunoHost-Apps/it-tools_ynh/releases/download/v2026.02.22-90e18130/it-tools_v2026.02.22-90e18130_ynh.zip"
+        sha256 = "70ca9cc21165149e21bd05b9d3c808f464296edf1b921b3769537ce39d7da32c"
         format = "zip"
         extract = true
         in_subdir = true


### PR DESCRIPTION
Upstream upgrade is now built for YNH and ready to be released in the current repository: https://github.com/YunoHost-Apps/it-tools_ynh/releases/tag/untagged-f4999035c4ab8412fe25
 - [x] Make sure the release is published before testing this PR.

